### PR TITLE
Fix misspelled file name

### DIFF
--- a/customlib.js
+++ b/customlib.js
@@ -5,7 +5,7 @@
   // unpkg
   //const modelViewerModuleUrl = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
   //  local
-  const modelViewerModuleUrl = './modelviewer.js';
+  const modelViewerModuleUrl = './modelViewer.js';
 
   await import(modelViewerModuleUrl);
 })();


### PR DESCRIPTION
When merged in, fixes the misspelled file name that leads to a crash. Fixes https://github.com/codefluegel/h5p-modelviewer-script/issues/1 / Fixes https://github.com/codefluegel/h5p-modelviewer-script/issues/3